### PR TITLE
Add MANIFEST.in to include README.md and LICENSE in dist. Fixes #14

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
As mentioned in #14, pip installs fail due to `README.md` not being included in the sdist, which causes `setup.py` to fail finding that file for the `long_description`

This PR adds a `MANIFEST.in` file to include both `README.md` and `LICENSE` in the tarball.
