### PR TITLE
Write to gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,22 @@ $ joe java    # outputs .gitignore file for java to stdout
 ### Overwrite existing `.gitignore` file
 
 ```bash
-$ joe java > .gitignore    # saves a new .gitignore file for java
+$ joe java --save        # saves a new .gitignore file for java
+$ joe java > .gitignore  # does the same thing
 ```
 
 ### Append to existing `.gitignore` file
 
 ```bash
-$ joe java >> .gitignore    # appends to an existing .gitignore file
+$ joe java --append       # appends to an existing .gitignore file
+$ joe java >> .gitignore  # does the same thing
 ```
 
 ### Multiple languages
 
 ```bash
-$ joe java node osx > .gitignore    # saves a new .gitignore file for multiple languages
+$ joe java node osx --save        # saves a new .gitignore file for multiple languages
+$ joe java node osx > .gitignore  # does the same thing
 ```
 
 ### Create and append to a global .gitignore file
@@ -72,7 +75,8 @@ You can also use joe to append to a global .gitignore. These can be helpful when
 
 ```bash
 $ git config --global core.excludesfile ~/.gitignore # Optional if you have not yet created a global .gitignore
-$ joe OSX SublimeText >> ~/.gitignore
+$ joe OSX SublimeText --append -o ~/.gitignore
+$ joe OSX SublimeText >> ~/.gitignore  # does the same thing as the line above
 ```
 
 ### List all available files
@@ -90,7 +94,8 @@ Output:
 Joe isn't **just** a generator for `.gitignore` files. You can use it and its output wherever a SCM is used.
 
 ```bash
-$ joe java > .hgignore
+$ joe java --save -o .hgignore
+$ joe java > .hgignore  # does the same thing
 ```
 
 ## Contributing

--- a/README.rst
+++ b/README.rst
@@ -64,21 +64,24 @@ Overwrite existing ``.gitignore`` file
 
 .. code:: bash
 
-    $ joe java > .gitignore    # saves a new .gitignore file for java
+    $ joe java --save        # saves a new .gitignore file for java
+    $ joe java > .gitignore  # does the same thing
 
 Append to existing ``.gitignore`` file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: bash
 
-    $ joe java >> .gitignore    # appends to an existing .gitignore file
+    $ joe java --append    # appends to an existing .gitignore file
+    $ joe java >> .gitignore  # does the same thing
 
 Multiple languages
 ~~~~~~~~~~~~~~~~~~
 
 .. code:: bash
 
-    $ joe java node osx > .gitignore    # saves a new .gitignore file for multiple languages
+    $ joe java node osx --save        # saves a new .gitignore file for multiple languages
+    $ joe java node osx > .gitignore  # does the same thing
 
 Create and append to a global .gitignore file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -90,7 +93,8 @@ otherwise.
 .. code:: bash
 
     $ git config --global core.excludesfile ~/.gitignore # Optional if you have not yet created a global .gitignore
-    $ joe OSX SublimeText >> ~/.gitignore
+    $ joe OSX SublimeText --append -o ~/.gitignore
+    $ joe OSX SublimeText >> ~/.gitignore  # does the same thing as the line above
 
 List all available files
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -134,7 +138,8 @@ and its output wherever a SCM is used.
 
 .. code:: bash
 
-    $ joe java > .hgignore
+    $ joe java --save -o .hgignore
+    $ joe java > .hgignore  # does the same thing
 
 Contributing
 ------------

--- a/joe/joe.py
+++ b/joe/joe.py
@@ -12,13 +12,20 @@ joe generates .gitignore files from the command line for you
 
 Usage:
   joe (ls | list)
-  joe [NAME...]
-  joe (-h | --help)
+  joe NAME ...
+  joe NAME ... (-a | --append | -s | --save) [-o FILE]
+  joe [-h | --help]
   joe --version
 
+Arguments:
+  NAME ...    Names of gitignore collections
+
 Options:
-  -h --help     Show this screen.
-  --version     Show version.
+  -a --append    Append to FILE
+  -h --help      Show this screen
+  -o FILE        Output file for appending/saving [default: .gitignore]
+  -s --save      Save to FILE
+  --version      Show version
 
 """
 
@@ -77,8 +84,6 @@ def _handle_gitignores(names):
             '\n%s\n'
             'Run `joe ls` to see list of available gitignores.\n'
         ) % "\n".join(failed))
-        output = []
-
     return output
 
 
@@ -114,7 +119,18 @@ def main():
     if arguments['ls'] or arguments['list']:
         print(_get_filenames())
     elif arguments['NAME']:
-        print(_handle_gitignores(arguments['NAME']))
+        output = _handle_gitignores(arguments['NAME'])
+        mode = None
+        if arguments['--save']:
+            mode = 'w'
+        elif arguments['--append']:
+            mode = 'a'
+        if mode:
+            filepath = arguments['-o']
+            with open(filepath, mode) as gitignore:
+                gitignore.write(output)
+        else:
+            print(output)
     else:
         print(__doc__)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.0.5'
+version = '0.0.6'
 
 setup(
     name='joe',


### PR DESCRIPTION
This PR implements issue #21, adding args for output instead of _requiring_ bash redirection (note that you can still just use bash redirect).
- `joe java > .gitignore`
  == `joe java --save`
- `joe java >> .gitignore`
  == `joe java --append`
- `joe java > /some/path/to/.gitignore`
  == `joe java --save -o /some/path/to/.gitignore`

`-a` and `-s` can be used instead of `--append` and `--save`, respectively.

Includes commit from my styled PR #23 for ease of merge conflicts.
