### PR TITLE
Add support to custom gitignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ Output:
 
 > actionscript, ada, agda, android, anjuta, appceleratortitanium, archives, archlinuxpackages, autotools, bricxcc, c, c++, cakephp, cfwheels, chefcookbook, clojure, cloud9, cmake, codeigniter, codekit, commonlisp, composer, concrete5, coq, craftcms, cvs, dart, darteditor, delphi, dm, dreamweaver, drupal, eagle, eclipse, eiffelstudio, elisp, elixir, emacs, ensime, episerver, erlang, espresso, expressionengine, extjs, fancy, finale, flexbuilder, forcedotcom, fortran, fuelphp, gcov, gitbook, go, gradle, grails, gwt, haskell, idris, igorpro, ipythonnotebook, java, jboss, jdeveloper, jekyll, jetbrains, joomla, jython, kate, kdevelop4, kohana, labview, laravel, lazarus, leiningen, lemonstand, libreoffice, lilypond, linux, lithium, lua, lyx, magento, matlab, maven, mercurial, mercury, metaprogrammingsystem, meteor, microsoftoffice, modelsim, momentics, monodevelop, nanoc, netbeans, nim, ninja, node, notepadpp, objective-c, ocaml, opa, opencart, oracleforms, osx, packer, perl, phalcon, playframework, plone, prestashop, processing, python, qooxdoo, qt, r, rails, redcar, redis, rhodesrhomobile, ros, ruby, rust, sass, sbt, scala, scons, scrivener, sdcc, seamgen, sketchup, slickedit, stella, sublimetext, sugarcrm, svn, swift, symfony, symphonycms, tags, tex, textmate, textpattern, tortoisegit, turbogears2, typo3, umbraco, unity, vagrant, vim, virtualenv, visualstudio, vvvv, waf, webmethods, windows, wordpress, xcode, xilinxise, xojo, yeoman, yii, zendframework, zephir
 
+###Add and remove custom gitignores
+
+
+```bash
+$ joe add my.gitignore    # OR `joe a my.gitignore`
+```
+
+
+Will make `joe my > .gitignore` work just as you expected. You can also
+write custom ignores for templates already available, for example
+
+```bash
+$ joe add laravel.gitignore
+```
+
+Next time you call `joe laravel > .gitignore` from your CLI, the custom gitignore will be used instead of the default one.
+
+To remove a custom gitignore, just run
+
+```bash
+$ joe remove laravel # OR `joe rm laravel`
+```
+
+And and the custom ignore will be removed.
+
+>NOTE: You can't remove default ignores, just the ones you added yourself
+
+
 ### BONUS ROUND: Alternate version control software
 
 Joe isn't **just** a generator for `.gitignore` files. You can use it and its output wherever a SCM is used.

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,34 @@ Output:
     windows, wordpress, xcode, xilinxise, xojo, yeoman, yii,
     zendframework, zephir
 
+Add and remove custom gitignores
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    $ joe add my.gitignore    # OR `joe a my.gitignore`
+
+Will make `joe my > .gitignore` work just as you expected. You can also
+write custom ignores for templates already available, for example
+
+.. code:: bash
+
+    $ joe add laravel.gitignore
+
+Next time you call `joe laravel > .gitignore` from your CLI, the custom gitignore will be used instead of the default one.
+
+To remove a custom gitignore, just run
+
+.. code:: bash
+
+	$ joe remove laravel # OR `joe rm laravel`
+
+And and the custom ignore will be removed.
+
+    NOTE: You can't remove default ignores, just the ones you added yourself
+
+
+
 BONUS ROUND: Alternate version control software
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/joe/joe.py
+++ b/joe/joe.py
@@ -12,6 +12,8 @@ joe generates .gitignore files from the command line for you
 
 Usage:
   joe (ls | list)
+  joe (add | a) <gitignore>
+  joe (remove | rm) <gitignore>
   joe [NAME...]
   joe (-h | --help)
   joe --version
@@ -25,14 +27,37 @@ Options:
 
 import os
 import sys
+import platform
+import operator
 
 from docopt import docopt
+from shutil import copyfile
+from os.path import expanduser
+from termcolor import colored
 
 
 __version__ = '0.0.5'
 
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
+PLATFORM = platform.system()
+_HOME = expanduser('~')
+
+
+def get_share_folder():
+    paths = {
+        'Darwin' : os.path.join(_HOME, '.joe'),
+        'Linux' : os.path.join(_HOME, '.joe'),
+        'Windows' : os.path.join(_HOME, '.joe')
+    }
+    path = paths[PLATFORM] or None
+    if path:
+        if not os.path.isdir(path):
+            os.mkdir(path)
+        return path
+    else:
+        print 'This is not a supported OS.'
+
 def _get_data_dir(path):
     '''Returns the path to the directory matching the passed `path`.'''
     return os.path.dirname(os.path.join(_ROOT, 'data', path))
@@ -40,23 +65,33 @@ def _get_data_dir(path):
 
 def _walk_gitignores():
     '''Recurse over the data directory and return all .gitignore file names'''
-    l = []
+    l = {}
     for root, subFolders, files in os.walk(DATA_DIR):
-        l += [f.replace('.gitignore', '') \
-                for f in files if f.endswith('.gitignore')]
-    return sorted(l)
+        for f in files:
+            if f.endswith('.gitignore'):
+                raw_name = f.replace('.gitignore', '')
+                l[raw_name.lower()] = colored(raw_name, 'blue')
+    for root, subFolder, files in os.walk(get_share_folder()):
+        for f in files:
+            if f.endswith('.gitignore'):
+                raw_name = f.replace('.gitignore', '')
+                l[raw_name.lower()] = colored(raw_name + '*', 'green')
+
+    return sorted(l.items(), key=operator.itemgetter(0))
 
 
 # Where all gitignore files are
 DATA_DIR = _get_data_dir('*.gitignore')
+SHARED_DATA_DIR = get_share_folder()
 # Load up names for all gitignore files
 GITIGNORE_RAW = _walk_gitignores()
-GITIGNORE = [f.lower() for f in GITIGNORE_RAW]
+GITIGNORE = [k for k,f in GITIGNORE_RAW]
+GITIGNORE_DISPLAY = [f.lower() for k,f in GITIGNORE_RAW]
 
 
 def _print_filenames():
     '''List all available .gitignore files.'''
-    print ', '.join(GITIGNORE)
+    print ', '.join(GITIGNORE_DISPLAY)
 
 
 def _handle_gitignores(names):
@@ -65,7 +100,7 @@ def _handle_gitignores(names):
     output = '#### joe made this: https://goel.io/joe\n'
     for name in names:
         try:
-            raw_name = GITIGNORE_RAW[GITIGNORE.index(name.lower())]
+            (raw_name, display_name) = GITIGNORE_RAW[GITIGNORE.index(name.lower())]
         except ValueError:
             print ('Uh oh! Seems like joe doesn\'t know what %s is.\n'
                    'Try running `joe ls` to see list of available gitignore '
@@ -91,21 +126,98 @@ def _fetch_gitignore(raw_name, directory=''):
         filepath = os.path.join(DATA_DIR, '%s' % directory + '/' + raw_name + \
                                                  '.gitignore')
     else:
+        custom_filepath = os.path.join(SHARED_DATA_DIR, raw_name + '.gitignore')
         filepath = os.path.join(DATA_DIR, raw_name + '.gitignore')
         output += '\n'
     try:
-        with open(filepath) as f:
+        with open(custom_filepath) as f:
             output += f.read()
         return output
     except IOError:
-        return _fetch_gitignore(raw_name, 'Global')
+        try:
+            with open(filepath) as f:
+                output += f.read()
+            return output
+        except IOError:
+            return _fetch_gitignore(raw_name, 'Global')
 
+def _add_custom_gitignore(new_gitignore):
+    '''Add a custom gitignore to the joe folder in the shared data folder.'''
+    share_folder = get_share_folder()
+    gitignore_file = new_gitignore if new_gitignore.endswith('.gitignore') else new_gitignore + '.gitignore'
+    if os.path.isfile(new_gitignore):
+        can_copy_file = True
+        if (os.path.isfile(os.path.join(share_folder, gitignore_file))):
+            can_copy_file = _confirm_selection('The file ' + colored(new_gitignore, 'green') + colored(' already exists.', 'red') + ' Do you wish to '+ colored('overwrite it', 'red') + '?', "no")
+        if can_copy_file:
+            try:
+                copyfile(new_gitignore, os.path.join(share_folder, gitignore_file))
+                print colored(new_gitignore, 'green') + ' was successfully added to joe.'
+            except OSError:
+                print 'Could not copy ' + colored(new_gitignore, 'red') + ' to ' + share_folder + '.\nCheck your permissions for both'
+        else:
+            print 'Ignoring ' + colored(new_gitignore, 'blue')
+    else:
+        print 'Could not copy ' + colored(new_gitignore, 'red') + ' to ' + colored(share_folder, 'red') + '.\nCheck your permissions for both'
+
+def _remove_custom_gitignore(gitignore_to_remove):
+    '''Remove a custom gitignore from the joe folder in the shared data folder.'''
+    share_folder = get_share_folder()
+    gitignore_file = gitignore_to_remove if gitignore_to_remove.endswith('.gitignore') else gitignore_to_remove +  '.gitignore'
+    if os.path.isfile(os.path.join(share_folder, gitignore_file)):
+        can_remove_file = _confirm_selection('This will remove ' + colored(gitignore_to_remove, 'red') + ' from your custom gitignores. Do you wish to continue?', "yes")
+        if can_remove_file:
+            try:
+                os.remove(os.path.join(share_folder, gitignore_file))
+                print 'The file ' + colored(gitignore_to_remove, 'red') + ' was successfully removed.'
+            except OSError:
+                print 'Could not remove ' + colored(gitignore_to_remove, 'red') + ' from ' + colored(share_folder, 'red') + '.\nCheck your permissions.'
+        else:
+            print 'Ok, ignoring ' + colored(gitignore_to_remove, 'green')
+    else:
+        print 'The file ' + colored(os.path.join(share_folder, gitignore_file), 'red') + ' was not found'
+
+def _confirm_selection(question, default="yes"):
+    """Ask a yes/no question via raw_input() and return their answer.
+
+    "question" is a string that is presented to the user.
+    "default" is the presumed answer if the user just hits <Enter>.
+        It must be "yes" (the default), "no" or None (meaning
+        an answer is required of the user).
+
+    The "answer" return value is True for "yes" or False for "no".
+    """
+    valid = {"yes": True, "y": True, "ye": True,
+             "no": False, "n": False}
+    if default is None:
+        prompt = " [y/n] "
+    elif default == "yes":
+        prompt = " ["+colored('Y', 'green')+"/n] "
+    elif default == "no":
+        prompt = " [y/"+colored('N', 'red')+"] "
+    else:
+        raise ValueError("invalid default answer: '%s'" % default)
+
+    while True:
+        sys.stdout.write(question + prompt)
+        choice = raw_input().lower()
+        if default is not None and choice == '':
+            return valid[default]
+        elif choice in valid:
+            return valid[choice]
+        else:
+            sys.stdout.write("Please respond with 'yes' or 'no' "
+                             "(or 'y' or 'n').\n")
 
 def main():
     arguments = docopt(__doc__, version=__version__)
 
     if (arguments['ls'] or arguments['list']):
         _print_filenames()
+    elif (arguments['add'] or arguments['a']):
+        _add_custom_gitignore(arguments['<gitignore>'])
+    elif (arguments['remove'] or arguments['rm']):
+        _remove_custom_gitignore(arguments['<gitignore>'])
     elif (arguments['NAME']):
         _handle_gitignores(arguments['NAME'])
     else:

--- a/joe/joe.py
+++ b/joe/joe.py
@@ -70,12 +70,12 @@ def _walk_gitignores():
         for f in files:
             if f.endswith('.gitignore'):
                 raw_name = f.replace('.gitignore', '')
-                _gitignores[raw_name.lower()] = colored(raw_name, 'blue')
+                _gitignores[raw_name.lower()] = {'filename': raw_name, 'displayname': colored(raw_name, 'blue')}
     for root, subFolder, files in os.walk(get_share_folder()):
         for f in files:
             if f.endswith('.gitignore'):
                 raw_name = f.replace('.gitignore', '')
-                _gitignores[raw_name.lower()] = colored(raw_name + '*', 'green')
+                _gitignores[raw_name.lower()] = {'filename': raw_name, 'displayname': colored(raw_name + '*', 'green')}
 
     return sorted(_gitignores.items(), key=operator.itemgetter(0))
 
@@ -85,9 +85,9 @@ DATA_DIR = _get_data_dir('*.gitignore')
 SHARED_DATA_DIR = get_share_folder()
 # Load up names for all gitignore files
 GITIGNORE_RAW = _walk_gitignores()
-GITIGNORE = [filename for filename,displayname in GITIGNORE_RAW]
-GITIGNORE_DISPLAY = [displayname.lower() for filename,displayname in GITIGNORE_RAW]
-
+GITIGNORE_INDEX = [raw_name for raw_name,gitignore in GITIGNORE_RAW] #The gitignore name, lowercased
+GITIGNORE_FILES = [gitignore['filename'] for raw_name,gitignore in GITIGNORE_RAW] #The gitignore name, as in the file
+GITIGNORE_DISPLAY = [gitignore['displayname'].lower() for raw_name,gitignore in GITIGNORE_RAW] #The gitignore name
 
 def _print_filenames():
     '''List all available .gitignore files.'''
@@ -99,7 +99,8 @@ def _handle_gitignores(names):
     output = '#### joe made this: https://goel.io/joe\n'
     for name in names:
         try:
-            (raw_name, display_name) = GITIGNORE_RAW[GITIGNORE.index(name.lower())]
+            gitignore_index = GITIGNORE_INDEX.index(name)
+            raw_name = GITIGNORE_FILES[gitignore_index]
         except ValueError:
             print ('Uh oh! Seems like joe doesn\'t know what %s is.\n'
                    'Try running `joe ls` to see list of available gitignore '
@@ -119,7 +120,7 @@ def _fetch_gitignore(raw_name, directory=''):
     directory must then be checked as string operations such as
         string + None return ''
     '''
-    output = '\n#####=== %s ===#####\n' % raw_name
+    output = '\n#####=== %s ===#####\n' % raw_name.lower()
     custom_filepath = os.path.join(SHARED_DATA_DIR, raw_name + '.gitignore')
     if directory:
         filepath = os.path.join(DATA_DIR, '%s/%s.gitignore' %

--- a/joe/joe.py
+++ b/joe/joe.py
@@ -99,7 +99,7 @@ def _handle_gitignores(names):
     output = '#### joe made this: https://goel.io/joe\n'
     for name in names:
         try:
-            gitignore_index = GITIGNORE_INDEX.index(name)
+            gitignore_index = GITIGNORE_INDEX.index(name.lower())
             raw_name = GITIGNORE_FILES[gitignore_index]
         except ValueError:
             print ('Uh oh! Seems like joe doesn\'t know what %s is.\n'

--- a/joe/joe.py
+++ b/joe/joe.py
@@ -122,11 +122,11 @@ def _fetch_gitignore(raw_name, directory=''):
         string + None return ''
     '''
     output = '\n#####=== %s ===#####\n' % raw_name
+    custom_filepath = os.path.join(SHARED_DATA_DIR, raw_name + '.gitignore')
     if directory:
         filepath = os.path.join(DATA_DIR, '%s' % directory + '/' + raw_name + \
                                                  '.gitignore')
     else:
-        custom_filepath = os.path.join(SHARED_DATA_DIR, raw_name + '.gitignore')
         filepath = os.path.join(DATA_DIR, raw_name + '.gitignore')
         output += '\n'
     try:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.0.5'
+version = '0.0.6'
 
 setup(
     name='joe',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     },
     install_requires=[
         'docopt>=0.6.1',
+        'termcolor>=1.1.0'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This adds two new commands: `joe add` and `joe remove`. This way you can
add your own custom gitignore files to joe.

In case of adding a custom file already available in the default list,
the custom one will be used. This should work fine in Windows too, but I
wasn't able to test it. Any feedback is apreciated.

A new dependency was added: termcolor, for colored output.

Address karan/joe#9
