### PR TITLE
add debian based build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ $ cd joe/
 $ python setup.py install
 ```
 
+If you use this method with Debian/Ubuntu and derivates you can use checkinstall to track down the package for easy removal.
+
+```bash
+$ sudo checkinstall --pkgname joe python setup.py install
+$ dpkg -r joe # this uninstalls joe
+```
+
 ## Usage
 
 ### Basic usage


### PR DESCRIPTION
This adds an easy way to track joe as an installed debian package. I personally prefer dpkg to install packages when I can over pip/sources since I can easily track them.
