### PR TITLE
Created search feature

### DIFF
--- a/joe/joe.py
+++ b/joe/joe.py
@@ -111,7 +111,7 @@ def _fetch_gitignore(raw_name, directory=''):
 
 def _search_gitignore(search_string):
     '''Searches and returns all matching .gitignore files.'''
-    matches = filter(lambda x: search_string.lower() in x,GITIGNORE)
+    matches = filter(lambda x: search_string.lower() in x, GITIGNORE)
     if matches:
         return ', '.join(matches)
     else:

--- a/joe/joe.py
+++ b/joe/joe.py
@@ -113,9 +113,11 @@ def _search_gitignore(search_string):
     '''Searches and returns all matching .gitignore files.'''
     matches = filter(lambda x: search_string.lower() in x, GITIGNORE)
     if matches:
-        return ', '.join(matches)
+        output = ', '.join(matches)
     else:
         sys.stderr.write(('No matches found for: \n%s\n') % search_string)
+        output = []
+    return output
 
 
 def main():

--- a/joe/joe.py
+++ b/joe/joe.py
@@ -13,12 +13,14 @@ joe generates .gitignore files from the command line for you
 Usage:
   joe (ls | list)
   joe [NAME...]
+  joe [-search STRING]
   joe (-h | --help)
   joe --version
 
 Options:
-  -h --help     Show this screen.
-  --version     Show version.
+  -s, --search STRING   Search for matching .gitignore files
+  -h --help             Show this screen.
+  --version             Show version.
 
 """
 
@@ -107,17 +109,27 @@ def _fetch_gitignore(raw_name, directory=''):
         return _fetch_gitignore(raw_name, 'Global')
 
 
+def _search_gitignore(search_string):
+    '''Searches and returns all matching .gitignore files.'''
+    matches = filter(lambda x: search_string.lower() in x,GITIGNORE)
+    if matches:
+        return ', '.join(matches)
+    else:
+        sys.stderr.write(('No matches found for: \n%s\n') % search_string)
+
+
 def main():
     '''joe generates .gitignore files from the command line for you'''
     arguments = docopt(__doc__, version=__version__)
 
     if arguments['ls'] or arguments['list']:
         print(_get_filenames())
+    elif arguments['--search']:
+        print(_search_gitignore(arguments['--search']))
     elif arguments['NAME']:
         print(_handle_gitignores(arguments['NAME']))
     else:
         print(__doc__)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Created fix for issue [48](https://github.com/karan/joe/issues/48). All gitignore files can now be searched with the `--search` or `-s` option. Example screenshot:
![search_joe](https://cloud.githubusercontent.com/assets/10348692/10263346/a5760ffc-69eb-11e5-8afe-27febaca09a7.jpg)
