### PR TITLE
Joe should update from the master branch, not

### DIFF
--- a/joe/joe.py
+++ b/joe/joe.py
@@ -75,7 +75,7 @@ def _update():
     repo = git.Repo.init(_DATA_DIR_PATH)
     origin = repo.create_remote('origin', REMOTE_URL)
     origin.fetch()
-    origin.pull(origin.refs[0].remote_head)
+    origin.pull('master')
     return 'Done'
 
 


### PR DESCRIPTION
Joe wasn't pulling the most recent files.  I tracked it down to what seemed to be a bug in that it was pulling `origin.refs[0].remote_head` instead of just `master`.  This was probably OK until a remote branch that was alphabetically before master appeared.
