### PR TITLE
update deps + minor formatting improvements, fixes, features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/karan/joe
+
+go 1.13
+
+require (
+	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae
+	github.com/urfave/cli v1.22.4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae h1:vgGSvdW5Lqg+I1aZOlG32uyE6xHpLdKhZzcTEktz5wM=
+github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae/go.mod h1:quDq6Se6jlGwiIKia/itDZxqC5rj6/8OdFyMMAwTxCs=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/joe.go
+++ b/joe.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-  "fmt"
-  "github.com/codegangsta/cli"
-  "io/ioutil"
-  "log"
-  "os"
-  "path"
-  "path/filepath"
-  "sort"
-  "strings"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/urfave/cli"
 )
 
 const joe string = `
@@ -25,134 +26,134 @@ const joe string = `
 ▐░░░░░░░▌    ▐░░░░░░░░░░░▌▐░░░░░░░░░░░▌
  ▀▀▀▀▀▀▀      ▀▀▀▀▀▀▀▀▀▀▀  ▀▀▀▀▀▀▀▀▀▀▀ 
 `
-const version string = "1.0.0"
-const gitignoreUrl = "https://github.com/github/gitignore/archive/master.zip"
+const version string = "1.0.3"
+const gitignoreURL = "https://github.com/github/gitignore/archive/master.zip"
 const dataDir string = ".joe-data"
 
 var dataPath = path.Join(os.Getenv("HOME"), dataDir)
 
 func findGitignores() (a map[string]string, err error) {
-  _, err = ioutil.ReadDir(dataPath)
-  if err != nil {
-    return nil, err
-  }
+	_, err = ioutil.ReadDir(dataPath)
+	if err != nil {
+		return nil, err
+	}
 
-  filelist := make(map[string]string)
-  filepath.Walk(dataPath, func(filepath string, info os.FileInfo, err error) error {
-    if strings.HasSuffix(info.Name(), ".gitignore") {
-      name := strings.ToLower(strings.Replace(info.Name(), ".gitignore", "", 1))
-      filelist[name] = filepath
-    }
-    return nil
-  })
-  return filelist, nil
+	filelist := make(map[string]string)
+	filepath.Walk(dataPath, func(filepath string, info os.FileInfo, err error) error {
+		if strings.HasSuffix(info.Name(), ".gitignore") {
+			name := strings.ToLower(strings.Replace(info.Name(), ".gitignore", "", 1))
+			filelist[name] = filepath
+		}
+		return nil
+	})
+	return filelist, nil
 }
 
 func availableFiles() (a []string, err error) {
-  gitignores, err := findGitignores()
-  if err != nil {
-    return nil, err
-  }
+	gitignores, err := findGitignores()
+	if err != nil {
+		return nil, err
+	}
 
-  availableGitignores := []string{}
-  for key, _ := range gitignores {
-    availableGitignores = append(availableGitignores, key)
-  }
+	availableGitignores := []string{}
+	for key := range gitignores {
+		availableGitignores = append(availableGitignores, key)
+	}
 
-  return availableGitignores, nil
+	return availableGitignores, nil
 }
 
 func generate(args string) {
-  names := strings.Split(args, ",")
+	names := strings.Split(args, ",")
 
-  gitignores, err := findGitignores()
-  if err != nil {
-    log.Fatal(err)
-  }
+	gitignores, err := findGitignores()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-  notFound := []string{}
-  output := ""
-  for index, name := range names {
-    if filepath, ok := gitignores[strings.ToLower(name)]; ok {
-      bytes, err := ioutil.ReadFile(filepath)
-      if err == nil {
-        output += "\n#### " + name + " ####\n"
-        output += string(bytes)
-        if index < len(names) - 1 {
-          output += "\n"
-        }
-        continue
-      }
-    } else {
-      notFound = append(notFound, name)
-    }
-  }
+	notFound := []string{}
+	output := ""
+	for index, name := range names {
+		if filepath, ok := gitignores[strings.ToLower(name)]; ok {
+			bytes, err := ioutil.ReadFile(filepath)
+			if err == nil {
+				output += "\n#### " + name + " ####\n"
+				output += string(bytes)
+				if index < len(names)-1 {
+					output += "\n"
+				}
+				continue
+			}
+		} else {
+			notFound = append(notFound, name)
+		}
+	}
 
-  if len(notFound) > 0 {
-    fmt.Printf("Unsupported files: %s\n", strings.Join(notFound, ", "))
-    fmt.Println("Run `joe ls` to see list of available gitignores.")
-    output = ""
-  }
-  if len(output) > 0 {
-    output = "#### joe made this: http://goel.io/joe\n" + output
-  }
-  fmt.Print(output)
+	if len(notFound) > 0 {
+		fmt.Printf("Unsupported files: %s\n", strings.Join(notFound, ", "))
+		fmt.Println("Run `joe ls` to see list of available gitignores.")
+		output = ""
+	}
+	if len(output) > 0 {
+		output = "#### joe made this: http://goel.io/joe\n" + output
+	}
+	fmt.Print(output)
 }
 
 func main() {
-  app := cli.NewApp()
-  app.Name = joe
-  app.Usage = "generate .gitignore files from the command line"
-  app.UsageText = "joe command [arguments...]"
-  app.Version = version
-  app.Commands = []cli.Command{
-    {
-      Name:    "ls",
-      Aliases: []string{"list"},
-      Usage:   "list all available files",
-      Action: func(c *cli.Context) error {
-        availableGitignores, err := availableFiles()
-        if err != nil {
-          log.Fatal(err)
-          return err
-        }
-        fmt.Printf("%d supported .gitignore files:\n", len(availableGitignores))
-        sort.Strings(availableGitignores)
-        fmt.Printf("%s\n", strings.Join(availableGitignores, ", "))
-        return nil
-      },
-    },
-    {
-      Name:    "u",
-      Aliases: []string{"update"},
-      Usage:   "update all available gitignore files",
-      Action: func(c *cli.Context) error {
-        fmt.Println("Updating gitignore files..")
-        err := RemoveContents(dataPath)
-        if err != nil {
-          log.Fatal(err)
-        }
-        err = DownloadFiles(gitignoreUrl, dataPath)
-        if err != nil {
-          log.Fatal(err)
-          return err
-        }
-        return nil
-      },
-    },
-    {
-      Name:    "g",
-      Aliases: []string{"generate"},
-      Usage:   "generate gitignore files",
-      Action: func(c *cli.Context) error {
-        if c.NArg() != 1 {
-          cli.ShowAppHelp(c)
-        } else {
-          generate(c.Args()[0])
-        }
-        return nil
-      },
-    },
-  }
-  app.Run(os.Args)
+	app := cli.NewApp()
+	app.Name = joe
+	app.Usage = "generate .gitignore files from the command line"
+	app.UsageText = "joe command [arguments...]"
+	app.Version = version
+	app.Commands = []cli.Command{
+		{
+			Name:    "ls",
+			Aliases: []string{"list"},
+			Usage:   "list all available files",
+			Action: func(c *cli.Context) error {
+				availableGitignores, err := availableFiles()
+				if err != nil {
+					log.Fatal(err)
+					return err
+				}
+				fmt.Printf("%d supported .gitignore files:\n", len(availableGitignores))
+				sort.Strings(availableGitignores)
+				fmt.Printf("%s\n", strings.Join(availableGitignores, ", "))
+				return nil
+			},
+		},
+		{
+			Name:    "u",
+			Aliases: []string{"update"},
+			Usage:   "update all available gitignore files",
+			Action: func(c *cli.Context) error {
+				fmt.Println("Updating gitignore files..")
+				err := RemoveContents(dataPath)
+				if err != nil {
+					log.Fatal(err)
+				}
+				err = DownloadFiles(gitignoreURL, dataPath)
+				if err != nil {
+					log.Fatal(err)
+					return err
+				}
+				return nil
+			},
+		},
+		{
+			Name:    "g",
+			Aliases: []string{"generate"},
+			Usage:   "generate gitignore files",
+			Action: func(c *cli.Context) error {
+				if c.NArg() != 1 {
+					cli.ShowAppHelp(c)
+				} else {
+					generate(c.Args()[0])
+				}
+				return nil
+			},
+		},
+	}
+	app.Run(os.Args)
 }

--- a/utils.go
+++ b/utils.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"archive/zip"
-	"github.com/termie/go-shutil"
 	"io"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/termie/go-shutil"
 )
 
 func unzip(archive, target string) (err error) {
@@ -47,6 +48,7 @@ func unzip(archive, target string) (err error) {
 	return nil
 }
 
+// DownloadFiles downloads contents of url to a temporary directory within dataPath
 func DownloadFiles(url string, dataPath string) (err error) {
 	archivePath := path.Join("/tmp", "master.zip")
 
@@ -84,6 +86,7 @@ func DownloadFiles(url string, dataPath string) (err error) {
 	return nil
 }
 
+// RemoveContents deletes dir and it's contents
 func RemoveContents(dir string) (err error) {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil


### PR DESCRIPTION
#### deps

* support golang v1.13
* migrate to Go Modules
* replace github.com/codegangsta/cli with github.com/urfave/cli

#### formatting

* reformat using `go fmt`
* address `golint` warnings
* address `shellcheck` warnings

#### fixes

* update `version` const in `joe.go` to `1.0.3`
* add `./build` prefix to executable path in `tool.sh run`

#### features

* set executable path based on host environment in `tool.sh run`
* forward remaining arguments to `joe` in `tool.sh run`
* redirect output to `stderr` in `usage` function of `tool.sh`

fixes karan/joe#91
closes karan/joe#104
closes karan/joe#100